### PR TITLE
feat: new API, reuse components, add entity to engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2100,8 +2100,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2122,14 +2121,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2144,20 +2141,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2274,8 +2268,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2287,7 +2280,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2302,7 +2294,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2310,14 +2301,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2336,7 +2325,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2417,8 +2405,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2430,7 +2417,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2516,8 +2502,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2553,7 +2538,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2573,7 +2557,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2617,14 +2600,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "ncc build src/index.ts -o dist --minify",
     "watch": "npm run build -- --watch",
-    "test": "ava",
+    "test": "ava test/**/*.test.ts",
     "precommit": "lint-staged"
   },
   "lint-staged": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,21 @@
+export function isLowerCaseChar(char: string) {
+  return !!char && char.length === 1 && char.toLowerCase() === char
+}
+
+/*
+Trasnform -> transfrom
+BoxShape -> boxShape
+GLTFShape -> gltfShape
+*/
+export function toCamelCase(pascalCase: string) {
+  let camelCase = ''
+  let shouldForceLowerCase = true
+  for (let i = 0; i < pascalCase.length; i++) {
+    camelCase += shouldForceLowerCase ? pascalCase[i].toLowerCase() : pascalCase[i]
+    // when the char following the next char to process is lowercase we stop forcing lower case
+    if (i < pascalCase.length - 2 && isLowerCaseChar(pascalCase[i + 2])) {
+      shouldForceLowerCase = false
+    }
+  }
+  return camelCase
+}

--- a/test/samples/index.ts
+++ b/test/samples/index.ts
@@ -1,0 +1,72 @@
+export const boxSample = `
+const box = new Entity()
+const boxShape = new BoxShape()
+box.addComponentOrReplace(boxShape)
+const transform = new Transform({
+  position: new Vector3(5, 0, 5),
+  rotation: new Quaternion(0, 0, 1, 0),
+  scale: new Vector3(1, 1, 1)
+})
+box.addComponentOrReplace(transform)
+engine.addEntity(box)`
+
+export const gltfSample = `
+const skeleton = new Entity()
+const gltfShape = new GLTFShape('./Skeleton.gltf')
+skeleton.addComponentOrReplace(gltfShape)
+const transform = new Transform({
+  position: new Vector3(0, 0, 0),
+  rotation: new Quaternion(0, 2, 1, 0),
+  scale: new Vector3(1, 1, 1)
+})
+skeleton.addComponentOrReplace(transform)
+engine.addEntity(skeleton)`
+
+export const sphereAndBoxSample = `
+const sphere = new Entity()
+const sphereShape = new SphereShape()
+sphere.addComponentOrReplace(sphereShape)
+engine.addEntity(sphere)
+
+const box = new Entity()
+const boxShape = new BoxShape()
+box.addComponentOrReplace(boxShape)
+engine.addEntity(box)`
+
+export const parentSample = `
+const sphere = new Entity()
+const sphereShape = new SphereShape()
+sphere.addComponentOrReplace(sphereShape)
+engine.addEntity(sphere)
+
+const box = new Entity()
+box.setParent(sphere)
+const boxShape = new BoxShape()
+box.addComponentOrReplace(boxShape)
+engine.addEntity(box)`
+
+export const reuseComponentSample = `
+const skeleton1 = new Entity()
+const gltfShape = new GLTFShape('./Skeleton.gltf')
+skeleton1.addComponentOrReplace(gltfShape)
+engine.addEntity(skeleton1)
+
+const skeleton2 = new Entity()
+skeleton2.addComponentOrReplace(gltfShape)
+engine.addEntity(skeleton2)`
+
+export const multipleComponentsSample = `
+const tree = new Entity()
+const gltfShape = new GLTFShape('./Tree.gltf')
+tree.addComponentOrReplace(gltfShape)
+engine.addEntity(tree)
+
+const rock = new Entity()
+const gltfShape_2 = new GLTFShape('./Rock.gltf')
+rock.addComponentOrReplace(gltfShape_2)
+engine.addEntity(rock)
+
+const ground = new Entity()
+const gltfShape_3 = new GLTFShape('./Ground.gltf')
+ground.addComponentOrReplace(gltfShape_3)
+engine.addEntity(ground)`

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -2,18 +2,18 @@ import test from 'ava'
 import { isLowerCaseChar, toCamelCase } from '../src/utils'
 
 test('Unit - isLowerCaseChar - should output true for "a"', t => {
-  t.is(isLowerCaseChar('a'), true)
+  t.true(isLowerCaseChar('a'))
 })
 
 test('Unit - isLowerCaseChar - should output false for "A"', t => {
-  t.is(isLowerCaseChar('A'), false)
+  t.false(isLowerCaseChar('A'))
 })
 
 test('Unit - toCamelCase - should output "transform"', t => {
   t.is(toCamelCase('Transform'), 'transform')
 })
 
-test('Unit - toCamelCase - should output "boxShape:', t => {
+test('Unit - toCamelCase - should output "boxShape"', t => {
   t.is(toCamelCase('BoxShape'), 'boxShape')
 })
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,30 @@
+import test from 'ava'
+import { isLowerCaseChar, toCamelCase } from '../src/utils'
+
+test('Unit - isLowerCaseChar - should output true for "a"', t => {
+  t.is(isLowerCaseChar('a'), true)
+})
+
+test('Unit - isLowerCaseChar - should output false for "A"', t => {
+  t.is(isLowerCaseChar('A'), false)
+})
+
+test('Unit - toCamelCase - should output "transform"', t => {
+  t.is(toCamelCase('Transform'), 'transform')
+})
+
+test('Unit - toCamelCase - should output "boxShape:', t => {
+  t.is(toCamelCase('BoxShape'), 'boxShape')
+})
+
+test('Unit - toCamelCase - should output "gltfShape"', t => {
+  t.is(toCamelCase('GLTFShape'), 'gltfShape')
+})
+
+test('Unit - toCamelCase - should output "api"', t => {
+  t.is(toCamelCase('API'), 'api')
+})
+
+test('Unit - toCamelCase - should output "soyUnCapo"', t => {
+  t.is(toCamelCase('SOYUnCapo'), 'soyUnCapo')
+})


### PR DESCRIPTION
Closes #3 

This PR changes the `.set` method to the new `.addComponentOrReplace`, also adds the missing `engine.addEntity(entity)` call that was preventing the scene from being rendered. 

Also this PR closes #3 by reusing the component instances.

I added more tests and also added a `test/samples` directory with the expected outputs for the unit tests in a more human-readable way, so we can update/maintain them easier.