### PR TITLE
feat: add support for NFTShape + tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1602,9 +1602,9 @@
       }
     },
     "decentraland-ecs": {
-      "version": "6.0.2-20190508203545.commit-c108e83",
-      "resolved": "https://registry.npmjs.org/decentraland-ecs/-/decentraland-ecs-6.0.2-20190508203545.commit-c108e83.tgz",
-      "integrity": "sha512-xfrTBvN13EWdagBEQL+0m3ZiJ5dR/6NqgSADif38VG4KZx7w++Br7weF7cmCYPS7ehzTCE76AN/vopLDMqdwBA==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/decentraland-ecs/-/decentraland-ecs-6.0.4.tgz",
+      "integrity": "sha512-hH9kmbyddEf7TMF+oeHJ6QGI+j4ip9NNl2G3RoDeWvXyD7FLUr2y3/Ez1c7I46USL1nHQ0EIkvxe/olBpHAOfg==",
       "dev": true,
       "requires": {
         "typescript": "^3.2.2",
@@ -5293,9 +5293,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz",
-      "integrity": "sha512-izPJg8RsSyqxbdnqX36ExpbH3K7tDBsAU/VfNv89VkMFy3z39zFjunQGsSHOlGlyIfGLGprGeosgQno3bo2/Kg==",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.12.tgz",
+      "integrity": "sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==",
       "dev": true,
       "requires": {
         "commander": "~2.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1602,18 +1602,20 @@
       }
     },
     "decentraland-ecs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ecs/-/decentraland-ecs-5.0.0.tgz",
-      "integrity": "sha512-ls2cS1bZO4VACg25ox3Rq6Qb47O2v2nZICkEHeHIIgIZqzzFrL++OQiZNpHXnePzPxFm/kgeEUlgBV0UYhPigw==",
+      "version": "6.0.2-20190508203545.commit-c108e83",
+      "resolved": "https://registry.npmjs.org/decentraland-ecs/-/decentraland-ecs-6.0.2-20190508203545.commit-c108e83.tgz",
+      "integrity": "sha512-xfrTBvN13EWdagBEQL+0m3ZiJ5dR/6NqgSADif38VG4KZx7w++Br7weF7cmCYPS7ehzTCE76AN/vopLDMqdwBA==",
+      "dev": true,
       "requires": {
         "typescript": "^3.2.2",
-        "uglify-js": "^3.4.9"
+        "uglify-js": "^3.5.2"
       },
       "dependencies": {
         "typescript": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.1.tgz",
-          "integrity": "sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA=="
+          "version": "3.4.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+          "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+          "dev": true
         }
       }
     },
@@ -5291,23 +5293,26 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz",
+      "integrity": "sha512-izPJg8RsSyqxbdnqX36ExpbH3K7tDBsAU/VfNv89VkMFy3z39zFjunQGsSHOlGlyIfGLGprGeosgQno3bo2/Kg==",
+      "dev": true,
       "requires": {
-        "commander": "~2.17.1",
+        "commander": "~2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@zeit/ncc": "^0.13.0",
     "ava": "^1.2.1",
     "dcl-tslint-config-standard": "^1.1.0",
-    "decentraland-ecs": "^6.0.2-20190508203545.commit-c108e83",
+    "decentraland-ecs": "^6.0.4",
     "husky": "^1.3.1",
     "lint-staged": "^8.1.1",
     "prettier": "^1.16.2",
@@ -58,7 +58,7 @@
     "tslint": "^5.12.1"
   },
   "peerDependencies": {
-    "decentraland-ecs": "^6.0.2"
+    "decentraland-ecs": "^6.0.4"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -50,13 +50,15 @@
     "@zeit/ncc": "^0.13.0",
     "ava": "^1.2.1",
     "dcl-tslint-config-standard": "^1.1.0",
+    "decentraland-ecs": "^6.0.2-20190508203545.commit-c108e83",
     "husky": "^1.3.1",
     "lint-staged": "^8.1.1",
     "prettier": "^1.16.2",
     "ts-node": "^8.0.2",
     "tslint": "^5.12.1"
   },
-  "dependencies": {
-    "decentraland-ecs": "^5.0.0"
-  }
+  "peerDependencies": {
+    "decentraland-ecs": "^6.0.2"
+  },
+  "dependencies": {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export default class SceneWriter {
       : `new ${constructorName}(${this.getConstructorValues(constructorName, component.data)})`
   }
 
-  private getEntityName(entity: DCL.Entity) {
+  private getEntityName(entity: DCL.IEntity) {
     let entityName: string
 
     this.entities.forEach((ent, name) => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -8,14 +8,9 @@ import {
   sphereAndBoxSample,
   parentSample,
   reuseComponentSample,
-  multipleComponentsSample
+  multipleComponentsSample,
+  ntfShape
 } from './samples'
-
-declare module 'decentraland-ecs' {
-  export class NFTShape {
-    constructor(path: string)
-  }
-}
 
 function sanitize(sample) {
   return sample.trim()
@@ -57,7 +52,7 @@ test('Should output code for an entity with NFTShape', t => {
   sceneWriter.addEntity('kitty', kitty)
   const code = sceneWriter.emitCode()
 
-  t.is(code, sanitize(gltfSample))
+  t.is(code, sanitize(ntfShape))
 })
 
 test('Should output code for two entities with SphereShape and BoxShape', t => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -11,6 +11,12 @@ import {
   multipleComponentsSample
 } from './samples'
 
+declare module 'decentraland-ecs' {
+  export class NFTShape {
+    constructor(path: string)
+  }
+}
+
 function sanitize(sample) {
   return sample.trim()
 }
@@ -18,8 +24,8 @@ function sanitize(sample) {
 test('Should output code for an entity with BoxShape and Transfrom', t => {
   const sceneWriter = new SceneWriter(DCL)
   const box = new DCL.Entity()
-  box.set(new DCL.BoxShape())
-  box.set(
+  box.addComponentOrReplace(new DCL.BoxShape())
+  box.addComponentOrReplace(
     new DCL.Transform({
       position: new DCL.Vector3(5, 0, 5),
       rotation: new DCL.Quaternion(0, 0, 1, 0)
@@ -34,9 +40,21 @@ test('Should output code for an entity with BoxShape and Transfrom', t => {
 test('Should output code for an entity with GLTFShape and Transform', t => {
   const sceneWriter = new SceneWriter(DCL)
   const skeleton = new DCL.Entity()
-  skeleton.set(new DCL.GLTFShape('./Skeleton.gltf'))
-  skeleton.set(new DCL.Transform({ rotation: new DCL.Quaternion(0, 2, 1, 0) }))
+  skeleton.addComponentOrReplace(new DCL.GLTFShape('./Skeleton.gltf'))
+  skeleton.addComponentOrReplace(new DCL.Transform({ rotation: new DCL.Quaternion(0, 2, 1, 0) }))
   sceneWriter.addEntity('skeleton', skeleton)
+  const code = sceneWriter.emitCode()
+
+  t.is(code, sanitize(gltfSample))
+})
+
+test('Should output code for an entity with NFTShape', t => {
+  const sceneWriter = new SceneWriter(DCL)
+  const kitty = new DCL.Entity()
+  kitty.addComponentOrReplace(
+    new DCL.NFTShape('ethereum://0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/38376')
+  )
+  sceneWriter.addEntity('kitty', kitty)
   const code = sceneWriter.emitCode()
 
   t.is(code, sanitize(gltfSample))
@@ -45,10 +63,10 @@ test('Should output code for an entity with GLTFShape and Transform', t => {
 test('Should output code for two entities with SphereShape and BoxShape', t => {
   const sceneWriter = new SceneWriter(DCL)
   const sphere = new DCL.Entity()
-  sphere.set(new DCL.SphereShape())
+  sphere.addComponentOrReplace(new DCL.SphereShape())
   sceneWriter.addEntity('sphere', sphere)
   const cube = new DCL.Entity()
-  cube.set(new DCL.BoxShape())
+  cube.addComponentOrReplace(new DCL.BoxShape())
   sceneWriter.addEntity('box', cube)
   const code = sceneWriter.emitCode()
   t.is(code, sanitize(sphereAndBoxSample))
@@ -57,7 +75,7 @@ test('Should output code for two entities with SphereShape and BoxShape', t => {
 test('Should throw an error when writing 2 entities with the same name', t => {
   const sceneWriter = new SceneWriter(DCL)
   const sphere = new DCL.Entity()
-  sphere.set(new DCL.SphereShape())
+  sphere.addComponentOrReplace(new DCL.SphereShape())
   sceneWriter.addEntity('sphere', sphere)
 
   t.throws(
@@ -69,11 +87,11 @@ test('Should throw an error when writing 2 entities with the same name', t => {
 test('Should output code for an entity with a parent', t => {
   const sceneWriter = new SceneWriter(DCL)
   const sphere = new DCL.Entity()
-  sphere.set(new DCL.SphereShape())
+  sphere.addComponentOrReplace(new DCL.SphereShape())
   sceneWriter.addEntity('sphere', sphere)
 
   const box = new DCL.Entity()
-  box.set(new DCL.BoxShape())
+  box.addComponentOrReplace(new DCL.BoxShape())
   box.setParent(sphere)
   sceneWriter.addEntity('box', box)
 
@@ -86,7 +104,7 @@ test('Should throw an error when writing an entity with a non-existent parent', 
   const sceneWriter = new SceneWriter(DCL)
   const sphere = new DCL.Entity()
   const cube = new DCL.Entity()
-  cube.set(new DCL.BoxShape())
+  cube.addComponentOrReplace(new DCL.BoxShape())
   cube.setParent(sphere)
   sceneWriter.addEntity('cube', cube)
 
@@ -101,9 +119,9 @@ test('Should output code for two entities that reuse a gltfShape component', t =
 
   const gltf = new DCL.GLTFShape('./Skeleton.gltf')
   const skeleton1 = new DCL.Entity()
-  skeleton1.set(gltf)
+  skeleton1.addComponentOrReplace(gltf)
   const skeleton2 = new DCL.Entity()
-  skeleton2.set(gltf)
+  skeleton2.addComponentOrReplace(gltf)
 
   sceneWriter.addEntity('skeleton1', skeleton1)
   sceneWriter.addEntity('skeleton2', skeleton2)
@@ -117,15 +135,15 @@ test('Should output code for multiple GLTFShape components with unique names', t
 
   const tree = new DCL.Entity()
   const treeShape = new DCL.GLTFShape('./Tree.gltf')
-  tree.set(treeShape)
+  tree.addComponentOrReplace(treeShape)
 
   const rock = new DCL.Entity()
   const rockShape = new DCL.GLTFShape('./Rock.gltf')
-  rock.set(rockShape)
+  rock.addComponentOrReplace(rockShape)
 
   const ground = new DCL.Entity()
   const groundShape = new DCL.GLTFShape('./Ground.gltf')
-  ground.set(groundShape)
+  ground.addComponentOrReplace(groundShape)
 
   sceneWriter.addEntity('tree', tree)
   sceneWriter.addEntity('rock', rock)

--- a/test/samples/index.ts
+++ b/test/samples/index.ts
@@ -22,6 +22,12 @@ const transform = new Transform({
 skeleton.addComponentOrReplace(transform)
 engine.addEntity(skeleton)`
 
+export const ntfShape = `
+const kitty = new Entity()
+const nftShape = new NFTShape('ethereum://0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/38376')
+kitty.addComponentOrReplace(nftShape)
+engine.addEntity(kitty)`
+
 export const sphereAndBoxSample = `
 const sphere = new Entity()
 const sphereShape = new SphereShape()


### PR DESCRIPTION
Closes #6 

Adds support for `NFTShape`.

**BLOCKED**: We need a version of the SDK that exposes the NFTShape so we can remove this: https://github.com/decentraland/dcl-scene-writer/pull/7/files#diff-22d221739f9dc3ffd50b561c1f3c1fb7R14