### PR TITLE
fix: remove unnecessary .addEntity from entities that have a parent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,9 @@ export default class SceneWriter {
       code += `${name}.addComponentOrReplace(${componentName})\n`
     }
 
-    code += `engine.addEntity(${name})\n`
+    if (!parent) {
+      code += `engine.addEntity(${name})\n`
+    }
 
     return code
   }

--- a/test/samples/index.ts
+++ b/test/samples/index.ts
@@ -48,8 +48,7 @@ engine.addEntity(sphere)
 const box = new Entity()
 box.setParent(sphere)
 const boxShape = new BoxShape()
-box.addComponentOrReplace(boxShape)
-engine.addEntity(box)`
+box.addComponentOrReplace(boxShape)`
 
 export const reuseComponentSample = `
 const skeleton1 = new Entity()


### PR DESCRIPTION
Closes #8 

If an entity has a parent added to the engine there is no need to add that child entity to the engine