### PR TITLE
fix: use latest ecs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1602,19 +1602,19 @@
       }
     },
     "decentraland-ecs": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/decentraland-ecs/-/decentraland-ecs-6.0.4.tgz",
-      "integrity": "sha512-hH9kmbyddEf7TMF+oeHJ6QGI+j4ip9NNl2G3RoDeWvXyD7FLUr2y3/Ez1c7I46USL1nHQ0EIkvxe/olBpHAOfg==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/decentraland-ecs/-/decentraland-ecs-6.4.2.tgz",
+      "integrity": "sha512-r1BDMurcrk1mZkeMqPmEaPY5TWHCQJpBChsWX1wWtXVUbiKdOP7w1cFp0HVPRWsgrut2rm8/9QdqV+VK6aKDnQ==",
       "dev": true,
       "requires": {
-        "typescript": "^3.2.2",
+        "typescript": "^3.4.5",
         "uglify-js": "^3.5.2"
       },
       "dependencies": {
         "typescript": {
-          "version": "3.4.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-          "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+          "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
           "dev": true
         }
       }
@@ -5312,12 +5312,12 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.5.12",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.12.tgz",
-      "integrity": "sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.2.tgz",
+      "integrity": "sha512-+gh/xFte41GPrgSMJ/oJVq15zYmqr74pY9VoM69UzMzq9NFk4YDylclb1/bhEzZSaUQjbW5RvniHeq1cdtRYjw==",
       "dev": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@zeit/ncc": "^0.13.0",
     "ava": "^1.2.1",
     "dcl-tslint-config-standard": "^1.1.0",
-    "decentraland-ecs": "^6.0.4",
+    "decentraland-ecs": "^6.4.2",
     "husky": "^1.3.1",
     "lint-staged": "^8.1.1",
     "prettier": "^1.16.2",

--- a/src/LightweightWriter.ts
+++ b/src/LightweightWriter.ts
@@ -80,7 +80,11 @@ export class LightweightWriter extends SceneWriter {
     return ''
   }
 
-  protected writeComponent(constructorName: string, component: DCL.ObservableComponent) {
+  protected writeComponent(
+    instanceName: string,
+    constructorName: string,
+    component: DCL.ObservableComponent
+  ) {
     return ''
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,3 +19,7 @@ export function toCamelCase(pascalCase: string) {
   }
   return camelCase
 }
+
+// Blacklist of ECS names
+
+export const blacklist = ['Shape', 'ObservableComponent']

--- a/test/LightweightWriter.test.ts
+++ b/test/LightweightWriter.test.ts
@@ -9,7 +9,8 @@ import {
   reuseComponentSample,
   multipleComponentsSample,
   ntfShape,
-  correctTransformName
+  correctTransformName,
+  componentAttributesSample
 } from './samples/LightweightWriter.data'
 
 import { LightweightWriter } from '../src/LightweightWriter'
@@ -72,7 +73,10 @@ test('Should output code for an entity with NFTShape', t => {
   const sceneWriter = new LightweightWriter(DCL)
   const kitty = new DCL.Entity()
   kitty.addComponentOrReplace(
-    new DCL.NFTShape('ethereum://0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/38376')
+    new DCL.NFTShape(
+      'ethereum://0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/38376',
+      new DCL.Color3(255, 0, 0)
+    )
   )
   sceneWriter.addEntity('kitty', kitty)
   const code = sceneWriter.emitCode()
@@ -172,4 +176,27 @@ test('Should output code for multiple GLTFShape components with unique names', t
   const code = sceneWriter.emitCode()
 
   t.is(sanitize(code), sanitize(multipleComponentsSample))
+})
+
+test('Should output the right value for component attributes that changed after instantiation', t => {
+  const sceneWriter = new LightweightWriter(DCL)
+
+  // Tree with collisions
+  const tree = new DCL.Entity()
+  const treeShape = new DCL.GLTFShape('./Tree.gltf')
+  treeShape.withCollisions = true
+  tree.addComponentOrReplace(treeShape)
+
+  // Rock without collisions
+  const rock = new DCL.Entity()
+  const rockShape = new DCL.GLTFShape('./Rock.gltf')
+  rockShape.withCollisions = false
+  rock.addComponentOrReplace(rockShape)
+
+  sceneWriter.addEntity('tree', tree)
+  sceneWriter.addEntity('rock', rock)
+
+  const code = sceneWriter.emitCode()
+
+  t.is(sanitize(code), sanitize(componentAttributesSample))
 })

--- a/test/SceneWriter.test.ts
+++ b/test/SceneWriter.test.ts
@@ -9,7 +9,8 @@ import {
   parentSample,
   reuseComponentSample,
   multipleComponentsSample,
-  ntfShape
+  ntfShape,
+  componentAttributesSample
 } from './samples/SceneWriter.data'
 
 function sanitize(sample) {
@@ -47,7 +48,10 @@ test('Should output code for an entity with NFTShape', t => {
   const sceneWriter = new SceneWriter(DCL)
   const kitty = new DCL.Entity()
   kitty.addComponentOrReplace(
-    new DCL.NFTShape('ethereum://0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/38376')
+    new DCL.NFTShape(
+      'ethereum://0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/38376',
+      new DCL.Color3(255, 0, 0)
+    )
   )
   sceneWriter.addEntity('kitty', kitty)
   const code = sceneWriter.emitCode()
@@ -147,4 +151,27 @@ test('Should output code for multiple GLTFShape components with unique names', t
   const code = sceneWriter.emitCode()
 
   t.is(sanitize(code), sanitize(multipleComponentsSample))
+})
+
+test('Should output the right value for component attributes that changed after instantiation', t => {
+  const sceneWriter = new SceneWriter(DCL)
+
+  // Tree with collisions
+  const tree = new DCL.Entity()
+  const treeShape = new DCL.GLTFShape('./Tree.gltf')
+  treeShape.withCollisions = true
+  tree.addComponentOrReplace(treeShape)
+
+  // Rock without collisions
+  const rock = new DCL.Entity()
+  const rockShape = new DCL.GLTFShape('./Rock.gltf')
+  rockShape.withCollisions = false
+  rock.addComponentOrReplace(rockShape)
+
+  sceneWriter.addEntity('tree', tree)
+  sceneWriter.addEntity('rock', rock)
+
+  const code = sceneWriter.emitCode()
+
+  t.is(sanitize(code), sanitize(componentAttributesSample))
 })

--- a/test/samples/LightweightWriter.data.ts
+++ b/test/samples/LightweightWriter.data.ts
@@ -4,7 +4,7 @@ dcl.subscribe('sceneStart');
 dcl.addEntity('1');
 dcl.setParent('1', '0');
 dcl.componentCreated('boxShape', 'engine.shape', 16);
-dcl.componentUpdated('boxShape', JSON.stringify({"withCollisions":false,"visible":true}));
+dcl.componentUpdated('boxShape', JSON.stringify({"withCollisions":true,"visible":true}));
 dcl.attachEntityComponent('1', 'engine.shape', 'boxShape');
 dcl.updateEntityComponent('1', 'engine.transform', 1, JSON.stringify({"position":{"x":5,"y":0,"z":5},"rotation":{"x":0,"y":0,"z":1,"w":0},"scale":{"x":1,"y":1,"z":1}}));
 `
@@ -15,7 +15,7 @@ dcl.subscribe('sceneStart');
 dcl.addEntity('1');
 dcl.setParent('1', '0');
 dcl.componentCreated('gltfShape', 'engine.shape', 54);
-dcl.componentUpdated('gltfShape', JSON.stringify({"withCollisions":false,"visible":true,"src":"./Skeleton.gltf"}));
+dcl.componentUpdated('gltfShape', JSON.stringify({"withCollisions":true,"visible":true,"src":"./Skeleton.gltf"}));
 dcl.attachEntityComponent('1', 'engine.shape', 'gltfShape');
 dcl.updateEntityComponent('1', 'engine.transform', 1, JSON.stringify({"position":{"x":0,"y":0,"z":0},"rotation":{"x":0,"y":2,"z":1,"w":0},"scale":{"x":1,"y":1,"z":1}}));
 `
@@ -26,7 +26,7 @@ dcl.subscribe('sceneStart');
 dcl.addEntity('1');
 dcl.setParent('1', '0');
 dcl.componentCreated('nftShape', 'engine.shape', 22);
-dcl.componentUpdated('nftShape', JSON.stringify({"withCollisions":false,"visible":true,"src":"ethereum://0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/38376"}));
+dcl.componentUpdated('nftShape', JSON.stringify({"withCollisions":true,"visible":true,"src":"ethereum://0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/38376","color":{"r":255,"g":0,"b":0}}));
 dcl.attachEntityComponent('1', 'engine.shape', 'nftShape');
 `
 
@@ -48,13 +48,13 @@ dcl.subscribe('sceneStart');
 dcl.addEntity('1');
 dcl.setParent('1', '0');
 dcl.componentCreated('sphereShape', 'engine.shape', 17);
-dcl.componentUpdated('sphereShape', JSON.stringify({"withCollisions":false,"visible":true}));
+dcl.componentUpdated('sphereShape', JSON.stringify({"withCollisions":true,"visible":true}));
 dcl.attachEntityComponent('1', 'engine.shape', 'sphereShape');
 
 dcl.addEntity('2');
 dcl.setParent('2', '0');
 dcl.componentCreated('boxShape', 'engine.shape', 16);
-dcl.componentUpdated('boxShape', JSON.stringify({"withCollisions":false,"visible":true}));
+dcl.componentUpdated('boxShape', JSON.stringify({"withCollisions":true,"visible":true}));
 dcl.attachEntityComponent('2', 'engine.shape', 'boxShape');
 `
 
@@ -64,13 +64,13 @@ dcl.subscribe('sceneStart');
 dcl.addEntity('1');
 dcl.setParent('1', '0');
 dcl.componentCreated('sphereShape', 'engine.shape', 17);
-dcl.componentUpdated('sphereShape', JSON.stringify({"withCollisions":false,"visible":true}));
+dcl.componentUpdated('sphereShape', JSON.stringify({"withCollisions":true,"visible":true}));
 dcl.attachEntityComponent('1', 'engine.shape', 'sphereShape');
 
 dcl.addEntity('2');
 dcl.setParent('2', '1');
 dcl.componentCreated('boxShape', 'engine.shape', 16);
-dcl.componentUpdated('boxShape', JSON.stringify({"withCollisions":false,"visible":true}));
+dcl.componentUpdated('boxShape', JSON.stringify({"withCollisions":true,"visible":true}));
 dcl.attachEntityComponent('2', 'engine.shape', 'boxShape');
 `
 
@@ -80,7 +80,7 @@ dcl.subscribe('sceneStart');
 dcl.addEntity('1');
 dcl.setParent('1', '0');
 dcl.componentCreated('gltfShape', 'engine.shape', 54);
-dcl.componentUpdated('gltfShape', JSON.stringify({"withCollisions":false,"visible":true,"src":"./Skeleton.gltf"}));
+dcl.componentUpdated('gltfShape', JSON.stringify({"withCollisions":true,"visible":true,"src":"./Skeleton.gltf"}));
 dcl.attachEntityComponent('1', 'engine.shape', 'gltfShape');
 
 dcl.addEntity('2');
@@ -94,7 +94,28 @@ dcl.subscribe('sceneStart');
 dcl.addEntity('1');
 dcl.setParent('1', '0');
 dcl.componentCreated('gltfShape', 'engine.shape', 54);
-dcl.componentUpdated('gltfShape', JSON.stringify({"withCollisions":false,"visible":true,"src":"./Tree.gltf"}));
+dcl.componentUpdated('gltfShape', JSON.stringify({"withCollisions":true,"visible":true,"src":"./Tree.gltf"}));
+dcl.attachEntityComponent('1', 'engine.shape', 'gltfShape');
+
+dcl.addEntity('2');
+dcl.setParent('2', '0');
+dcl.componentCreated('gltfShape_2', 'engine.shape', 54);
+dcl.componentUpdated('gltfShape_2', JSON.stringify({"withCollisions":true,"visible":true,"src":"./Rock.gltf"}));
+dcl.attachEntityComponent('2', 'engine.shape', 'gltfShape_2');
+
+dcl.addEntity('3');
+dcl.setParent('3', '0');
+dcl.componentCreated('gltfShape_3', 'engine.shape', 54);
+dcl.componentUpdated('gltfShape_3', JSON.stringify({"withCollisions":true,"visible":true,"src":"./Ground.gltf"}));
+dcl.attachEntityComponent('3', 'engine.shape', 'gltfShape_3');`
+
+export const componentAttributesSample = `
+dcl.subscribe('sceneStart');
+
+dcl.addEntity('1');
+dcl.setParent('1', '0');
+dcl.componentCreated('gltfShape', 'engine.shape', 54);
+dcl.componentUpdated('gltfShape', JSON.stringify({"withCollisions":true,"visible":true,"src":"./Tree.gltf"}));
 dcl.attachEntityComponent('1', 'engine.shape', 'gltfShape');
 
 dcl.addEntity('2');
@@ -102,9 +123,4 @@ dcl.setParent('2', '0');
 dcl.componentCreated('gltfShape_2', 'engine.shape', 54);
 dcl.componentUpdated('gltfShape_2', JSON.stringify({"withCollisions":false,"visible":true,"src":"./Rock.gltf"}));
 dcl.attachEntityComponent('2', 'engine.shape', 'gltfShape_2');
-
-dcl.addEntity('3');
-dcl.setParent('3', '0');
-dcl.componentCreated('gltfShape_3', 'engine.shape', 54);
-dcl.componentUpdated('gltfShape_3', JSON.stringify({"withCollisions":false,"visible":true,"src":"./Ground.gltf"}));
-dcl.attachEntityComponent('3', 'engine.shape', 'gltfShape_3');`
+`

--- a/test/samples/SceneWriter.data.ts
+++ b/test/samples/SceneWriter.data.ts
@@ -1,6 +1,8 @@
 export const boxSample = `const box = new Entity()
 engine.addEntity(box)
 const boxShape = new BoxShape()
+boxShape.withCollisions = true
+boxShape.visible = true
 box.addComponentOrReplace(boxShape)
 const transform = new Transform({
   position: new Vector3(5, 0, 5),
@@ -11,7 +13,9 @@ box.addComponentOrReplace(transform)`
 
 export const gltfSample = `const skeleton = new Entity()
 engine.addEntity(skeleton)
-const gltfShape = new GLTFShape('./Skeleton.gltf')
+const gltfShape = new GLTFShape("./Skeleton.gltf")
+gltfShape.withCollisions = true
+gltfShape.visible = true
 skeleton.addComponentOrReplace(gltfShape)
 const transform = new Transform({
   position: new Vector3(0, 0, 0),
@@ -23,36 +27,48 @@ skeleton.addComponentOrReplace(transform)`
 export const ntfShape = `
 const kitty = new Entity()
 engine.addEntity(kitty)
-const nftShape = new NFTShape('ethereum://0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/38376')
+const nftShape = new NFTShape("ethereum://0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/38376", {"r":255,"g":0,"b":0})
+nftShape.withCollisions = true
+nftShape.visible = true
 kitty.addComponentOrReplace(nftShape)`
 
 export const sphereAndBoxSample = `
 const sphere = new Entity()
 engine.addEntity(sphere)
 const sphereShape = new SphereShape()
+sphereShape.withCollisions = true
+sphereShape.visible = true
 sphere.addComponentOrReplace(sphereShape)
 
 const box = new Entity()
 engine.addEntity(box)
 const boxShape = new BoxShape()
+boxShape.withCollisions = true
+boxShape.visible = true
 box.addComponentOrReplace(boxShape)`
 
 export const parentSample = `
 const sphere = new Entity()
 engine.addEntity(sphere)
 const sphereShape = new SphereShape()
+sphereShape.withCollisions = true
+sphereShape.visible = true
 sphere.addComponentOrReplace(sphereShape)
 
 const box = new Entity()
 engine.addEntity(box)
 box.setParent(sphere)
 const boxShape = new BoxShape()
+boxShape.withCollisions = true
+boxShape.visible = true
 box.addComponentOrReplace(boxShape)`
 
 export const reuseComponentSample = `
 const skeleton1 = new Entity()
 engine.addEntity(skeleton1)
-const gltfShape = new GLTFShape('./Skeleton.gltf')
+const gltfShape = new GLTFShape("./Skeleton.gltf")
+gltfShape.withCollisions = true
+gltfShape.visible = true
 skeleton1.addComponentOrReplace(gltfShape)
 
 const skeleton2 = new Entity()
@@ -62,15 +78,37 @@ skeleton2.addComponentOrReplace(gltfShape)`
 export const multipleComponentsSample = `
 const tree = new Entity()
 engine.addEntity(tree)
-const gltfShape = new GLTFShape('./Tree.gltf')
+const gltfShape = new GLTFShape("./Tree.gltf")
+gltfShape.withCollisions = true
+gltfShape.visible = true
 tree.addComponentOrReplace(gltfShape)
 
 const rock = new Entity()
 engine.addEntity(rock)
-const gltfShape_2 = new GLTFShape('./Rock.gltf')
+const gltfShape_2 = new GLTFShape("./Rock.gltf")
+gltfShape_2.withCollisions = true
+gltfShape_2.visible = true
 rock.addComponentOrReplace(gltfShape_2)
 
 const ground = new Entity()
 engine.addEntity(ground)
-const gltfShape_3 = new GLTFShape('./Ground.gltf')
+const gltfShape_3 = new GLTFShape("./Ground.gltf")
+gltfShape_3.withCollisions = true
+gltfShape_3.visible = true
 ground.addComponentOrReplace(gltfShape_3)`
+
+export const componentAttributesSample = `
+const tree = new Entity()
+engine.addEntity(tree)
+const gltfShape = new GLTFShape("./Tree.gltf")
+gltfShape.withCollisions = true
+gltfShape.visible = true
+tree.addComponentOrReplace(gltfShape)
+
+const rock = new Entity()
+engine.addEntity(rock)
+const gltfShape_2 = new GLTFShape("./Rock.gltf")
+gltfShape_2.withCollisions = false
+gltfShape_2.visible = true
+rock.addComponentOrReplace(gltfShape_2)
+`


### PR DESCRIPTION
This PR makesthe package work with the latest version of `decentraland-ecs`. The thing that was breaking it was that the shape of the api definition changed (probably due to an upgrade in the tool used to generate it). 

I fixed that and I also added a feature that was missing, which is emitting the component attributes in the generated code. 

Before that change, the code emitted by the following was the same either for this:

```js
const entity = new Entity()
const shape = new GLTFShape('pepe.gltf')
entity.addComponent(shape)
writer.addEntity('shape', shape)
```

Than this:

```js
const entity = new Entity()
const shape = new GLTFShape('pepe.gltf')
shape.withCollisions = true
entity.addComponent(shape)
writer.addEntity('shape', shape)
```

Now, all the attributes are emitted in the code:

```
const entity = new Entity()
const shape = new GLTFShape('pepe.gltf')
shape.withCollisions = true
shape.visible = true
entity.addComponent(shape)
```

I added a test to the `SceneWriter` and another one to `LightweightWriter` to test this feature.